### PR TITLE
Fix tmux pbcopy/pbpaste issue

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -91,3 +91,4 @@ set-option -g set-titles on
 set-option -g set-titles-string '#W(#P) - #T'
 set-window-option -g automatic-rename on
 
+set-option -g default-command "reattach-to-user-namespace -l zsh"


### PR DESCRIPTION
pbcopy and pbpaste don't works in tmux session, this fixes.

`brew install reattach-to-user-namespace` first
